### PR TITLE
.npmignore: Do not package the tmp/ dir.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 bower_components/
 tests/
+tmp/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
Saves about 53 MiB (86%) from your npm package installed size.
See https://github.com/ember-cli/ember-cli/issues/4199 for details.
